### PR TITLE
change status_visible_to_responders to true

### DIFF
--- a/public_interest/public_records_request.yml
+++ b/public_interest/public_records_request.yml
@@ -35,7 +35,7 @@ project_params:
   show_advanced_ratings: false
   show_askers: true
   show_respondents: true
-  statuses_visible_to_responders: false
+  statuses_visible_to_responders: true
   summary: Submit a public records request to the City of San Narciso.
 response_fields:
 - label: Additional Contact Information


### PR DESCRIPTION
Since this feature seems especially valuable for FOIA-related requests, let's set the default option in the template to true.
