### PR TITLE
Fix formatting

### DIFF
--- a/public_interest/public_records_request.yml
+++ b/public_interest/public_records_request.yml
@@ -20,7 +20,7 @@ project_params:
     relevant to your request,</li><li>allow you to view the records immediately, for
     free, during business hours,</li><li>respond within 10 days</li><li>and justify
     withholding of any records by showing that public interest in confidentiality
-    outweighs public interest in disclosure.</li></ul><br><br>The City of San Narciso
+    outweighs public interest in disclosure.</li></ul><br>The City of San Narciso
     may ask for a 14-day extension if we are required to sort through a large number
     of documents, retrieve the document from a facility outside of City Hall, consult
     with another agency, or write a computer program to retrieve data you have requested.<br>'

--- a/rfp/foundation_letter_of_inquiry.yml
+++ b/rfp/foundation_letter_of_inquiry.yml
@@ -3,7 +3,7 @@ project_params:
   after_response_email: true
   after_response_page: true
   after_response_page_html: Thank you for submitting a letter of inquiry to The Beta
-    Foundation!<br>
+    Foundation!
   identification_level: 2
   automatically_approve_edits: false
   automatically_release_responses_for_edits: false

--- a/survey/post-event-survey.yml
+++ b/survey/post-event-survey.yml
@@ -3,7 +3,7 @@ project_params:
   after_response_email: false
   after_response_page: true
   after_response_page_html: Thank you for taking the time to share your thoughts!
-    We hope to see you at the next Maptime Sacramento event.<br><br>Until then, happy
+    We hope to see you at the next Maptime Sacramento event. Until then, happy
     mapping!
   identification_level: 1
   automatically_approve_edits: false


### PR DESCRIPTION
Checking out all the templates on the template preview page, I noticed `<br>` tags in the after response email field are rendered in plain text, so I removed them here.
